### PR TITLE
Add sticky header with working mobile menu

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "WebSearch"
     ],
     "deny": [],
     "ask": []

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,5 +1,6 @@
 ---
-import { SITE_TITLE, GA_ID } from '../consts';
+import { ClientRouter } from "astro:transitions";
+import { SITE_TITLE, GA_ID } from "../consts";
 
 interface Props {
   title: string;
@@ -7,9 +8,12 @@ interface Props {
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const { title, description = '' } = Astro.props;
+const { title, description = "" } = Astro.props;
 const fullTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 ---
+
+<!-- Client-side router for smooth navigation -->
+<ClientRouter />
 
 <!-- Global Metadata -->
 <meta charset="utf-8" />
@@ -29,7 +33,7 @@ const fullTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
   rel="alternate"
   type="application/rss+xml"
   title={SITE_TITLE}
-  href={new URL('/feed.xml', Astro.site)}
+  href={new URL("/feed.xml", Astro.site)}
 />
 
 <!-- Sitemap -->
@@ -38,12 +42,27 @@ const fullTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 <!-- Google Analytics -->
 <script is:inline define:vars={{ GA_ID }}>
   if (document.location.hostname.search("treymack.com") !== -1) {
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    (function (i, s, o, g, r, a, m) {
+      i["GoogleAnalyticsObject"] = r;
+      ((i[r] =
+        i[r] ||
+        function () {
+          (i[r].q = i[r].q || []).push(arguments);
+        }),
+        (i[r].l = 1 * new Date()));
+      ((a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]));
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m);
+    })(
+      window,
+      document,
+      "script",
+      "https://www.google-analytics.com/analytics.js",
+      "ga",
+    );
 
-    ga('create', GA_ID, 'auto');
-    ga('send', 'pageview');
+    ga("create", GA_ID, "auto");
+    ga("send", "pageview");
   }
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,8 +14,13 @@ import { SITE_TITLE } from "../consts";
       {SITE_TITLE}
     </a>
 
-    <nav class="site-nav">
-      <button class="menu-icon md:hidden p-2" aria-label="Toggle menu">
+    <nav class="site-nav relative">
+      <button
+        id="menu-toggle"
+        class="menu-icon md:hidden p-2"
+        aria-label="Toggle menu"
+        aria-expanded="false"
+      >
         <svg viewBox="0 0 18 15" class="w-5 h-4">
           <path
             fill="#424242"
@@ -32,13 +37,60 @@ import { SITE_TITLE } from "../consts";
         </svg>
       </button>
 
-      <div class="trigger hidden md:flex gap-4">
+      <!-- Desktop menu -->
+      <div class="hidden md:flex gap-4">
         <a
           href="/about"
           class="page-link text-gray-600 hover:text-gray-900 no-underline"
           >About</a
         >
       </div>
+
+      <!-- Mobile menu dropdown -->
+      <div
+        id="mobile-menu"
+        class="mobile-menu hidden absolute right-0 top-full mt-2 bg-white border border-gray-300 rounded-lg shadow-lg py-2 min-w-32 md:hidden"
+      >
+        <a
+          href="/about"
+          class="block px-4 py-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 no-underline"
+          >About</a
+        >
+      </div>
     </nav>
   </div>
 </header>
+
+<script>
+  // Use event delegation on document to handle clicks
+  // This works reliably with transition:persist since we're not adding
+  // listeners to the persisted elements themselves
+  document.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+    const toggle = document.getElementById("menu-toggle");
+    const menu = document.getElementById("mobile-menu");
+
+    if (!toggle || !menu) return;
+
+    // Handle hamburger button click
+    if (toggle.contains(target)) {
+      const isOpen = menu.classList.contains("hidden");
+      menu.classList.toggle("hidden");
+      toggle.setAttribute("aria-expanded", isOpen.toString());
+      return;
+    }
+
+    // Handle menu link click - close menu
+    if (menu.contains(target) && target.tagName === "A") {
+      menu.classList.add("hidden");
+      toggle.setAttribute("aria-expanded", "false");
+      return;
+    }
+
+    // Click outside - close menu
+    if (!menu.contains(target)) {
+      menu.classList.add("hidden");
+      toggle.setAttribute("aria-expanded", "false");
+    }
+  });
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,24 +1,43 @@
 ---
-import { SITE_TITLE } from '../consts';
+import { SITE_TITLE } from "../consts";
 ---
 
-<header class="site-header border-b border-gray-300">
+<header
+  transition:persist
+  class="site-header sticky top-0 z-50 bg-white border-b border-gray-300"
+>
   <div class="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
-    <a href="/" class="site-title text-xl font-bold text-gray-800 no-underline hover:text-gray-600">
+    <a
+      href="/"
+      class="site-title text-xl font-bold text-gray-800 no-underline hover:text-gray-600"
+    >
       {SITE_TITLE}
     </a>
 
     <nav class="site-nav">
       <button class="menu-icon md:hidden p-2" aria-label="Toggle menu">
         <svg viewBox="0 0 18 15" class="w-5 h-4">
-          <path fill="#424242" d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"/>
-          <path fill="#424242" d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,7.516z"/>
-          <path fill="#424242" d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"/>
+          <path
+            fill="#424242"
+            d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"
+          ></path>
+          <path
+            fill="#424242"
+            d="M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0c0-0.82,0.665-1.484,1.484-1.484 h15.031C17.335,6.031,18,6.696,18,7.516L18,7.516z"
+          ></path>
+          <path
+            fill="#424242"
+            d="M18,13.516C18,14.335,17.335,15,16.516,15H1.484C0.665,15,0,14.335,0,13.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.031C17.335,12.031,18,12.696,18,13.516L18,13.516z"
+          ></path>
         </svg>
       </button>
 
       <div class="trigger hidden md:flex gap-4">
-        <a href="/about" class="page-link text-gray-600 hover:text-gray-900 no-underline">About</a>
+        <a
+          href="/about"
+          class="page-link text-gray-600 hover:text-gray-900 no-underline"
+          >About</a
+        >
       </div>
     </nav>
   </div>

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -136,4 +136,65 @@ test.describe("Site pages", () => {
     const boundingBox = await header.boundingBox();
     expect(boundingBox?.y).toBe(0);
   });
+
+  test("mobile menu toggles on hamburger click", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+
+    const menuToggle = page.locator("#menu-toggle");
+    const mobileMenu = page.locator("#mobile-menu");
+
+    // Menu should be hidden initially
+    await expect(mobileMenu).toBeHidden();
+
+    // Click hamburger to open menu
+    await menuToggle.click();
+    await expect(mobileMenu).toBeVisible();
+    await expect(menuToggle).toHaveAttribute("aria-expanded", "true");
+
+    // Menu should contain About link
+    await expect(mobileMenu.locator('a[href="/about"]')).toBeVisible();
+
+    // Click hamburger again to close menu
+    await menuToggle.click();
+    await expect(mobileMenu).toBeHidden();
+  });
+
+  test("mobile menu closes after clicking a link", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+
+    const menuToggle = page.locator("#menu-toggle");
+    const mobileMenu = page.locator("#mobile-menu");
+
+    // Open menu and click About link
+    await menuToggle.click();
+    await expect(mobileMenu).toBeVisible();
+
+    await mobileMenu.locator('a[href="/about"]').click();
+
+    // Should navigate to about page
+    await expect(page).toHaveURL(/\/about/);
+  });
+
+  test("mobile menu works after navigating to a post", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+
+    // Click on a blog post link
+    await page.locator('a[href*="/blog/"]').first().click();
+    await expect(page).toHaveURL(/\/blog\//);
+
+    // Now test that the hamburger menu still works
+    const menuToggle = page.locator("#menu-toggle");
+    const mobileMenu = page.locator("#mobile-menu");
+
+    await expect(mobileMenu).toBeHidden();
+    await menuToggle.click();
+    await expect(mobileMenu).toBeVisible();
+
+    // Click About link from the post page
+    await mobileMenu.locator('a[href="/about"]').click();
+    await expect(page).toHaveURL(/\/about/);
+  });
 });

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -103,4 +103,37 @@ test.describe("Site pages", () => {
     await page.click('a[href="/"]');
     await expect(page).toHaveURL(/\/$/);
   });
+
+  test("header is sticky and visible after scrolling", async ({ page }) => {
+    await page.goto("/");
+    const header = page.locator("header.site-header");
+
+    // Verify header has sticky positioning
+    const position = await header.evaluate(
+      (el) => getComputedStyle(el).position,
+    );
+    expect(position).toBe("sticky");
+
+    // Scroll down the page
+    await page.evaluate(() => window.scrollBy(0, 500));
+
+    // Header should still be visible at top
+    await expect(header).toBeVisible();
+    const boundingBox = await header.boundingBox();
+    expect(boundingBox?.y).toBe(0);
+  });
+
+  test("header is sticky on mobile viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 }); // iPhone SE size
+    await page.goto("/");
+    const header = page.locator("header.site-header");
+
+    // Scroll down
+    await page.evaluate(() => window.scrollBy(0, 300));
+
+    // Header should still be visible at top
+    await expect(header).toBeVisible();
+    const boundingBox = await header.boundingBox();
+    expect(boundingBox?.y).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Make header sticky at top of viewport (works on mobile too)
- Add working mobile hamburger menu with dropdown
- Add ClientRouter for smooth page transitions without flicker
- Use event delegation for reliable menu after view transitions
- Add `transition:persist` to header to prevent re-render flicker

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] All 15 Playwright tests pass (`npm test`)
- [ ] CI workflow runs on this PR
- [ ] Manual test: hamburger menu works on mobile
- [ ] Manual test: menu works after navigating to a post

🤖 Generated with [Claude Code](https://claude.ai/code)