### PR TITLE
Fix lodash prototype pollution vulnerability (Dependabot #13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4372,9 +4372,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test:unit": "vitest run",
     "test:e2e": "playwright test"
   },
+  "overrides": {
+    "lodash": ">=4.17.23"
+  },
   "dependencies": {
     "@astrojs/check": "^0.9.6",
     "@astrojs/mdx": "^4.3.13",


### PR DESCRIPTION
## Summary

Fixes Dependabot security alert #13 by upgrading lodash from vulnerable version 4.17.21 to patched version 4.17.23.

## Changes

- Add npm `overrides` field to force lodash >=4.17.23
- Update package-lock.json with patched version

## Security Details

- **Vulnerability:** Prototype Pollution in `_.unset` and `_.omit` functions
- **Severity:** Medium
- **CVE:** Lodash prototype pollution
- **Vulnerable Range:** >= 4.0.0, <= 4.17.22
- **Patched Version:** 4.17.23

Lodash is a transitive dependency via:
`@astrojs/check` → `@astrojs/language-server` → `volar-service-yaml` → `yaml-language-server` → `lodash`

## Test Plan

- [x] Build passes with astro check
- [x] All 27 unit tests pass
- [x] All 15 e2e tests pass
- [x] npm audit shows 0 vulnerabilities
- [x] Pre-commit hooks pass

**Note:** This commit was accidentally pushed directly to master. Creating this PR for proper review tracking even though the commit is already on master.