### PR TITLE
Add Giscus comments to blog posts

### DIFF
--- a/src/components/CommentsSection.astro
+++ b/src/components/CommentsSection.astro
@@ -1,0 +1,31 @@
+---
+import {
+  GISCUS_REPO,
+  GISCUS_REPO_ID,
+  GISCUS_CATEGORY,
+  GISCUS_CATEGORY_ID,
+} from "../consts";
+---
+
+<div class="comments-section mt-12 pt-8 border-t border-gray-200">
+  <h2 class="text-2xl font-bold mb-6">Comments</h2>
+
+  <script
+    is:inline
+    src="https://giscus.app/client.js"
+    data-repo={GISCUS_REPO}
+    data-repo-id={GISCUS_REPO_ID}
+    data-category={GISCUS_CATEGORY}
+    data-category-id={GISCUS_CATEGORY_ID}
+    data-mapping="pathname"
+    data-strict="0"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="top"
+    data-theme="light"
+    data-lang="en"
+    data-loading="lazy"
+    crossorigin="anonymous"
+    async
+  ></script>
+</div>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,9 +1,33 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-export const SITE_TITLE = 'Trey Mack';
-export const SITE_DESCRIPTION = 'I am a full stack web developer specializing in reactive web applications and integration. Feel free to contact me on Twitter or via email.';
-export const SITE_EMAIL = 'tmack10@gmail.com';
-export const TWITTER_USERNAME = 'trey_mack';
-export const GITHUB_USERNAME = 'treymack';
-export const GA_ID = 'UA-96898181-1';
+export const SITE_TITLE = "Trey Mack";
+export const SITE_DESCRIPTION =
+  "I am a full stack web developer specializing in reactive web applications and integration. Feel free to contact me on Twitter or via email.";
+export const SITE_EMAIL = "tmack10@gmail.com";
+export const TWITTER_USERNAME = "trey_mack";
+export const GITHUB_USERNAME = "treymack";
+export const GA_ID = "UA-96898181-1";
+
+export const GISCUS_SCRIPT = `
+<script src="https://giscus.app/client.js"
+        data-repo="treymack/treymack.github.io"
+        data-repo-id="MDEwOlJlcG9zaXRvcnkzODkwNDU3Ng=="
+        data-category="Announcements"
+        data-category-id="DIC_kwDOAlGjAM4C1ypE"
+        data-mapping="pathname"
+        data-strict="0"
+        data-reactions-enabled="1"
+        data-emit-metadata="0"
+        data-input-position="bottom"
+        data-theme="preferred_color_scheme"
+        data-lang="en"
+        data-loading="lazy"
+        crossorigin="anonymous"
+        async>
+</script>`;
+// Giscus comments configuration
+export const GISCUS_REPO = "treymack/treymack.github.io";
+export const GISCUS_REPO_ID = "MDEwOlJlcG9zaXRvcnkzODkwNDU3Ng=="; // From giscus.app
+export const GISCUS_CATEGORY = "Announcements";
+export const GISCUS_CATEGORY_ID = "DIC_kwDOAlGjAM4C1ypE"; // From giscus.app

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -3,6 +3,7 @@ import { Image } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 import FormattedDate from "../components/FormattedDate.astro";
+import CommentsSection from "../components/CommentsSection.astro";
 
 type Props = CollectionEntry<"blog">["data"];
 
@@ -42,5 +43,7 @@ const { title, date, description, updatedDate, heroImage } = Astro.props;
     <article class="post-content prose prose-lg max-w-none">
       <slot />
     </article>
+
+    <CommentsSection />
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary

- Adds Giscus comment system to all blog posts
- Comments stored in GitHub Discussions (Announcements category)
- Supports threaded conversations and reactions
- Moderation via GitHub Discussions interface

## Implementation

- Created `CommentsSection.astro` component with Giscus widget
- Integrated component into `PostLayout.astro` 
- Updated Giscus configuration to use correct category

## Test plan

- [x] Tested locally - comments widget loads correctly
- [x] Comments update properly when navigating between posts
- [x] Posted test comment successfully
- [x] Verified comment appears in GitHub Discussions
- [ ] Deploy and test on production (treymack.com)
- [ ] Verify mobile responsiveness
- [ ] Test moderation features