### PR TITLE
Add SEO meta descriptions across site

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,6 +1,6 @@
 ---
 import { ClientRouter } from "astro:transitions";
-import { SITE_TITLE, GA_ID } from "../consts";
+import { SITE_TITLE, SITE_DESCRIPTION, GA_ID } from "../consts";
 
 interface Props {
   title: string;
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const { title, description = "" } = Astro.props;
+const { title, description = SITE_DESCRIPTION } = Astro.props;
 const fullTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 ---
 
@@ -26,7 +26,7 @@ const fullTitle = title === SITE_TITLE ? title : `${title} | ${SITE_TITLE}`;
 
 <!-- Primary Meta Tags -->
 <title>{fullTitle}</title>
-{description && <meta name="description" content={description} />}
+<meta name="description" content={description} />
 
 <!-- RSS Feed -->
 <link

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -17,7 +17,7 @@ const renderedEntries = await Promise.all(
 );
 ---
 
-<PageLayout title="About">
+<PageLayout title="About" description={SITE_DESCRIPTION}>
   <h1 class="text-3xl font-bold mb-4">$ whois treymack</h1>
 
   <p class="mb-4">{SITE_DESCRIPTION}</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import FormattedDate from "../components/FormattedDate.astro";
-import { SITE_TITLE } from "../consts";
+import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 import { getPostUrl } from "../utils/slugs";
 import { processPostsExcerpts } from "../utils/excerpts";
 
@@ -13,7 +13,7 @@ const posts = (await getCollection("blog")).sort(
 const postsWithExcerpts = await processPostsExcerpts(posts);
 ---
 
-<BaseLayout title={SITE_TITLE}>
+<BaseLayout title={SITE_TITLE} description={SITE_DESCRIPTION}>
   <div class="home">
     <h1 class="page-heading text-2xl font-bold mb-6">Posts</h1>
 


### PR DESCRIPTION
## Summary

- Updates BaseHead component to use SITE_DESCRIPTION as default fallback for meta descriptions
- Adds explicit meta description to home page using SITE_DESCRIPTION
- Adds explicit meta description to about page using SITE_DESCRIPTION
- Blog posts already use descriptions from frontmatter when available

## Benefits

- Improves SEO with proper meta descriptions on all pages
- Search engines will now display meaningful snippets in search results
- Ensures consistent fallback description across the site

## Test plan

- [x] Run dev server and view page source for home page - verify `<meta name="description">` tag contains SITE_DESCRIPTION
- [x] Check about page source - verify meta description tag is present
- [x] Check a blog post - verify it uses post-specific description if available
- [x] Verify meta descriptions appear in search engine previews (can use tools like metatags.io)